### PR TITLE
Rename crate from ptouch to ql-label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptouch"
+name = "ql-label"
 version = "0.2.1"
 dependencies = [
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "ptouch"
+name = "ql-label"
 version = "0.2.1"
 authors = ["Yasuyuki Komatsubara <kyasuyako@gmail.com"]
-description = "Rust P-Touch Printer Driver"
+description = "Brother QL series label printer driver for Rust"
 license = "MIT"
-homepage = "https://github.com/kyasu1/ptouch"
-repository = "https://github.com/kyasu1/ptouch.git"
+homepage = "https://github.com/kyasu1/rust-ptouch-usb"
+repository = "https://github.com/kyasu1/rust-ptouch-usb.git"
 readme = "README.md"
-keywords = ["usb", "libusb", "rusb", "ptouch" ]
+keywords = ["brother", "ql", "label", "printer", "usb"]
 edition = "2018"
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ptouch
+# ql-label
 
 This crate provides raster printing capability for Brother P-Touch QL series label printers connected as USB device.
 It allows to print programmatically generated label images.
@@ -32,7 +32,7 @@ The samples show:
 Choose a media tape you want to use and install it in the printer, then specify the matching media.
 
 ```rust
-let media = ptouch::Media::Continuous(ContinuousType::Continuous62);
+let media = ql_label::Media::Continuous(ContinuousType::Continuous62);
 ```
 
 Theare are two types of media tape, Continuous and DieCut, each one has several size variations. In this example we choose Continuous tape with 62mm width.
@@ -113,12 +113,12 @@ let file = "examples/rust-logo.png";
 let image: image::DynamicImage = image::open(file).unwrap();
 let (_, length) = image.dimensions();
 let gray = image.grayscale();
-let mut buffer = image::DynamicImage::new_luma8(ptouch::WIDE_PRINTER_WIDTH, length);
+let mut buffer = image::DynamicImage::new_luma8(ql_label::WIDE_PRINTER_WIDTH, length);
 buffer.invert();
 buffer.copy_from(&gray, 0, 0).unwrap();
 buffer.invert();
 let bytes = buffer.to_bytes();
-let bw = ptouch::utils::step_filter_normal(80, length, bytes);
+let bw = ql_label::utils::step_filter_normal(80, length, bytes);
 ```
 
 #### Two-Color Image Data
@@ -129,12 +129,12 @@ For two-color printing, you can either:
 ```rust
 let rgb_img = image::open("image.png")?.to_rgb8();
 let (width, height) = rgb_img.dimensions();
-let two_color_data = ptouch::convert_rgb_to_two_color(width, height, rgb_img.as_raw())?;
+let two_color_data = ql_label::convert_rgb_to_two_color(width, height, rgb_img.as_raw())?;
 ```
 
 2. **Create TwoColorMatrix manually**:
 ```rust
-let two_color_data = ptouch::TwoColorMatrix::new(black_matrix, red_matrix)?;
+let two_color_data = ql_label::TwoColorMatrix::new(black_matrix, red_matrix)?;
 ```
 
 The color detection automatically identifies:
@@ -194,7 +194,7 @@ The following models are tested by myself.
 - QL-800
 - QL-820NWB
 
-Anothre printers listed in the `ptouch::Model` should also work but we might need to some tweaking.
+Another printers listed in the `ql_label::Model` should also work but we might need some tweaking.
 
 ## Tools
 
@@ -221,8 +221,8 @@ RUST_LOG=debug cargo run --example print_two_color image path/to/your/image.png
 This will show something like follows.
 
 ```
-[2020-10-27T06:05:45Z DEBUG ptouch::printer] Raw status code: [80, 20, 42, 34, 38, 30, 0, 0, 0, 0, 1D, A, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
-[2020-10-27T06:05:45Z DEBUG ptouch::printer] Parsed Status struct: Status { model: QL800, error: UnknownError(0), media: Some(Continuous(Continuous29)), mode: 0, status_type: ReplyToRequest, phase: Receiving, notification: NotAvailable }
+[2020-10-27T06:05:45Z DEBUG ql_label::printer] Raw status code: [80, 20, 42, 34, 38, 30, 0, 0, 0, 0, 1D, A, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0]
+[2020-10-27T06:05:45Z DEBUG ql_label::printer] Parsed Status struct: Status { model: QL800, error: UnknownError(0), media: Some(Continuous(Continuous29)), mode: 0, status_type: ReplyToRequest, phase: Receiving, notification: NotAvailable }
 ```
 
 Some gathered data are saved in `printer_status.txt`.

--- a/examples/init.rs
+++ b/examples/init.rs
@@ -1,4 +1,4 @@
-use ptouch::{Config, DieCutType, Media, Model, Printer};
+use ql_label::{Config, DieCutType, Media, Model, Printer};
 use std::env;
 
 fn main() {

--- a/examples/print_rust.rs
+++ b/examples/print_rust.rs
@@ -1,5 +1,5 @@
 use image::{GenericImage, GenericImageView};
-use ptouch::{step_filter_normal, Config, ContinuousType, Matrix, Media, Model, Printer};
+use ql_label::{step_filter_normal, Config, ContinuousType, Matrix, Media, Model, Printer};
 use qrcode::QrCode;
 use std::env;
 
@@ -170,7 +170,7 @@ impl Iterator for Label {
             let (_, length) = image.dimensions();
             let image = image.grayscale();
 
-            let mut buffer = image::DynamicImage::new_luma8(ptouch::NORMAL_PRINTER_WIDTH, length);
+            let mut buffer = image::DynamicImage::new_luma8(ql_label::NORMAL_PRINTER_WIDTH, length);
             buffer.invert();
             buffer.copy_from(&image, 0, 0).unwrap();
             buffer.invert();
@@ -201,7 +201,7 @@ impl Iterator for Label2 {
                 .min_dimensions(100, 200)
                 .build();
 
-            let mut buffer = image::DynamicImage::new_luma8(ptouch::NORMAL_PRINTER_WIDTH, length);
+            let mut buffer = image::DynamicImage::new_luma8(ql_label::NORMAL_PRINTER_WIDTH, length);
             buffer.invert();
             buffer.copy_from(&qrcode, 0, 0).unwrap();
 

--- a/examples/print_two_color.rs
+++ b/examples/print_two_color.rs
@@ -1,4 +1,4 @@
-use ptouch::{
+use ql_label::{
     convert_rgb_to_two_color, Config, ContinuousType, Media, Model, Printer, TwoColorMatrix,
 };
 use std::env;
@@ -119,7 +119,7 @@ fn main() {
 }
 
 fn create_test_pattern() -> TwoColorMatrix {
-    let width = ptouch::NORMAL_PRINTER_WIDTH;
+    let width = ql_label::NORMAL_PRINTER_WIDTH;
     let height = 300;
     let byte_width = (width + 7) / 8;
 
@@ -166,7 +166,7 @@ fn load_and_convert_image(path: &str) -> Result<TwoColorMatrix, String> {
     println!("Loading image: {}x{} pixels", width, height);
 
     // Resize if needed to fit printer width
-    let target_width = ptouch::NORMAL_PRINTER_WIDTH;
+    let target_width = ql_label::NORMAL_PRINTER_WIDTH;
     let (final_img, final_width, final_height) = if width != target_width {
         let aspect_ratio = height as f32 / width as f32;
         let new_height = (target_width as f32 * aspect_ratio) as u32;

--- a/examples/read_status.rs
+++ b/examples/read_status.rs
@@ -1,4 +1,4 @@
-use ptouch::{Config, ContinuousType, Media, Model, Printer};
+use ql_label::{Config, ContinuousType, Media, Model, Printer};
 use std::env;
 
 fn main() {


### PR DESCRIPTION
## Summary
- Renamed the crate from `ptouch` to `ql-label` to avoid conflicts with existing crates
- Updated all documentation and examples to use the new crate name
- Enhanced package metadata for better discoverability

## Changes
- **Package name**: Changed from `ptouch` to `ql-label`
- **Description**: Enhanced to "Brother QL series label printer driver for Rust"
- **Keywords**: Updated to ["brother", "ql", "label", "printer", "usb"] for better discoverability
- **Repository URLs**: Fixed to match current GitHub repository
- **README.md**: Updated title and all code examples to use `ql_label::`
- **Examples**: All example files now use `ql_label` crate name and constants

## Benefits of New Name
- **Avoids conflicts**: No collision with existing `ptouch` and `ptouch-rs` crates on crates.io
- **Clear purpose**: `ql-label` clearly indicates Brother QL series label printer support
- **Future-proof**: Name doesn't tie to specific connection method (USB), allowing future expansion
- **Memorable**: Short, descriptive name that's easy to remember and type

## Breaking Changes
This is a breaking change for any existing users, but since the crate hasn't been published to crates.io yet, this is the optimal time to make this change.

## Test plan
- [x] All examples compile and work correctly with new crate name
- [x] Library builds without errors
- [x] Documentation examples are accurate
- [x] Package metadata is complete and correct

🤖 Generated with [Claude Code](https://claude.ai/code)